### PR TITLE
Add config manager, string utils, and CI improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,4 +17,5 @@ Checks: >
   openmp-*,
   performance-*,
   portability-*,
-  misc-*
+  misc-*,
+  -misc-include-cleaner

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '30 1 * * *'
 
 jobs:
   analyze:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Create Coverage Reports
         run: |
           mkdir cov_report
-          lcov -c -d build/ -o cov_report/lcov.info --include "*include*"
+          lcov -c -d build/ -o cov_report/lcov.info --include "*include*" --exclude "*test*" --exclude "*third_party*"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
@@ -74,7 +74,7 @@ jobs:
           sudo apt install -y ninja-build clang clang-tidy-17
 
       - name: Configure CMake
-        run: cmake -B build -S . -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_CLANG_TIDY="clang-tidy-17;-warnings-as-errors=*"
+        run: cmake -B build -S . -G Ninja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTING=OFF -DCMAKE_CXX_CLANG_TIDY="clang-tidy-17;-warnings-as-errors=*"
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Create Coverage Reports
         run: |
           mkdir cov_report
-          lcov -c -d build/ -o cov_report/lcov.info --include "*include*" --exclude "*test*" "*third_party*"
+          lcov -c -d build/ -o cov_report/lcov.info
+          lcov -r cov_report/lcov.info '/usr/*' 'third_party/*' -o cov_report/lcov.info
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Create Coverage Reports
         run: |
           mkdir cov_report
-          lcov -c -d build/ -o cov_report/lcov.info --include "*include*" --exclude "*test*" --exclude "*third_party*"
+          lcov -c -d build/ -o cov_report/lcov.info --include "*include*" --exclude "*test*" "*third_party*"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -19,8 +19,12 @@ jobs:
           - compiler: clang
             cc: clang
             cxx: clang++
+          - arch: x64
+            os: ubuntu-latest
+          - arch: x64
+            os: ARM64
 
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
         arch: [x64, arm64]

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: true
       matrix:
         configuration: [Debug, Release]
+        arch: [x64, arm64]
         compiler: [gcc, clang]
         include:
           - compiler: gcc
@@ -21,10 +22,10 @@ jobs:
             cxx: clang++
           - arch: x64
             os: ubuntu-latest
-          - arch: x64
-            os: ARM64
+          - arch: arm64
+            os: rasp-arm64
 
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -40,6 +40,7 @@ jobs:
         g++
         clang
         build-essential
+        ninja-build
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
@@ -50,6 +51,7 @@ jobs:
         CXX: ${{matrix.cxx}}
       run: >-
         cmake
+        -G Ninja
         -S "${{github.workspace}}"
         -B "${{github.workspace}}/build"
         -DCMAKE_BUILD_TYPE=${{matrix.configuration}}

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         configuration: [Debug, Release]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.25)
 
 ###########################################################
 # Global settings                                         #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.28)
 ###########################################################
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 23)
 endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -81,6 +81,11 @@ if(CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 include(GNUInstallDirs)
+
+install(DIRECTORY
+  "${CMAKE_CURRENT_SOURCE_DIR}/config/"
+  DESTINATION "config"
+  FILES_MATCHING PATTERN "*.ini")
 
 set(CPACK_PACKAGE_FILE_NAME
   "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${GIT_SHORT_SHA}-${CMAKE_SYSTEM_NAME}-${CMAKE_BUILD_TYPE}-${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ enable_testing()
 # Redirect outputs                                        #
 ###########################################################
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL "" FORCE)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH} CACHE INTERNAL "" FORCE)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE INTERNAL "" FORCE)
 
 get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,21 @@ project(
   HOMEPAGE_URL "knoodlegraph.org"
   LANGUAGES CXX C)
 
+enable_testing()
+
+###########################################################
+# Redirect outputs                                        #
+###########################################################
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL "" FORCE)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE INTERNAL "" FORCE)
+
+get_property(GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(GENERATOR_IS_MULTI_CONFIG)
+  set(TESTS_OUTPUT_DIR ${EXECUTABLE_OUTPUT_PATH}/tests/$<CONFIG>/ CACHE INTERNAL "" FORCE)
+else()
+  set(TESTS_OUTPUT_DIR ${EXECUTABLE_OUTPUT_PATH}/tests/ CACHE INTERNAL "" FORCE)
+endif()
+
 ###########################################################
 # Global Options                                          #
 ###########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.25)
 ###########################################################
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 23)
+  set(CMAKE_CXX_STANDARD 20)
 endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/cmake/KnoodleModule.cmake
+++ b/cmake/KnoodleModule.cmake
@@ -74,7 +74,7 @@ function(knoodle_create_module)
 
   # force include the export header
   target_compile_options(${KNOODLE_MODULE_NAME}
-    PRIVATE
+    PUBLIC
       $<$<CXX_COMPILER_ID:MSVC>:/FI${KNOODLE_MODULE_NAME}_export.h>
       $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-include ${KNOODLE_MODULE_NAME}_export.h>) 
 

--- a/config/engine.ini
+++ b/config/engine.ini
@@ -1,0 +1,17 @@
+[General]
+AppName=KnoodleEngine
+Version=1.0.0
+
+[Window]
+Width=1280
+Height=720
+AspectRatio=1.778
+Fullscreen=Off
+
+[Audio]
+MasterVolume=75
+MusicVolume=60
+SFXVolume=80
+
+[Graphics]
+API=Vulkan

--- a/include/core/common.hpp
+++ b/include/core/common.hpp
@@ -1,0 +1,32 @@
+/**************************************************************************/
+/* common.hpp                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+using real_t = float;

--- a/include/core/config/config_manager.hpp
+++ b/include/core/config/config_manager.hpp
@@ -1,0 +1,128 @@
+/**************************************************************************/
+/* config_manager.hpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "common.hpp"
+
+namespace kn {
+/**
+ * Manages the configuration of the application.
+ * The configuration is read from a file and stored in memory.
+ */
+class KN_CORE_API ConfigManager {
+  ConfigManager() = default;
+
+ public:
+  ~ConfigManager() = default;
+
+  static ConfigManager& get_instance();
+
+  /**
+   * Loads the configuration from a file and append it to the current configuration.
+   * @param file_path The path to the file to load.
+   * @return True if the file was successfully loaded, false otherwise.
+   */
+  bool load_config(const std::filesystem::path& file_path);
+
+  /** Return a set of all the registered sections. */
+  [[nodiscard]] std::set<std::string> get_sections() const;
+
+  /**
+   * Returns a value by key.
+   * @param key The key to search for.
+   * @return The value associated with the key, if it exists.
+   */
+  [[nodiscard]] std::optional<std::string> get_value(const std::string_view& key) const;
+
+  /**
+   * Returns a value by key as integer.
+   * @param key The key to search for.
+   * @return The value associated with the key, if it exists.
+   */
+  [[nodiscard]] std::optional<int32_t> get_int_value(const std::string_view& key) const;
+
+  /**
+   * Returns a value by key as real_t.
+   * @param key The key to search for.
+   * @return The value associated with the key, if it exists.
+   */
+  [[nodiscard]] std::optional<real_t> get_real_value(const std::string_view& key) const;
+
+  /**
+   * Returns a value by key as boolean.
+   * @param key The key to search for.
+   * @return The value associated with the key, if it exists.
+   */
+  [[nodiscard]] std::optional<bool> get_bool_value(const std::string_view& key) const;
+
+ protected:
+  /**
+   * Parses a line from the configuration file.
+   * @param line The line to parse.
+   */
+  virtual void parse_line(const std::string_view& line);
+  /**
+   * Parses a key-value pair from a line.
+   * @param line The line to parse.
+   */
+  virtual void parse_key_value(const std::string_view& line);
+  /**
+   * Parses a comment from a line.
+   * @param line The line to parse.
+   */
+  virtual void parse_comment(const std::string_view& line);
+  /**
+   * Parses a section from a line.
+   * @param line The line to parse.
+   */
+  virtual void parse_section(const std::string_view& line);
+  /**
+   * Parses a blank line from a line.
+   * @param line The line to parse.
+   */
+  virtual void parse_blank(const std::string_view& line);
+  /**
+   * Parses a line from the configuration file.
+   * @param line The line to parse.
+   */
+
+ private:
+  std::unordered_map<std::string, std::string> _config;
+
+  std::string _current_section;
+};
+}  // namespace kn

--- a/include/core/math/kn_math.hpp
+++ b/include/core/math/kn_math.hpp
@@ -29,8 +29,9 @@
 
 #pragma once
 
+#include "common.hpp"
+
 namespace kn::math {
-using real_t = float;
 
 template <typename T>
 concept number = std::integral<T> or std::floating_point<T>;

--- a/include/core/string_utils.hpp
+++ b/include/core/string_utils.hpp
@@ -34,16 +34,22 @@
 
 namespace kn::string_utils {
 /** Trims a string */
-inline auto trim(const std::string_view& str) {
-  auto v = str | std::views::drop_while(isspace) | std::views::reverse | std::views::drop_while(isspace) |
-           std::views::reverse;
+inline std::string trim(const std::string_view& str) {
+  auto isSpace = [](unsigned char c) { return std::isspace(c); };
+  auto first = std::ranges::find_if_not(str, isSpace);
+  if (first == str.end()) {
+    return {};
+  }
 
-  return std::string(v.begin(), v.end());
+  auto last = std::ranges::find_if_not(std::views::reverse(str), isSpace);
+  auto baseIt = last.base();
+
+  return {first, baseIt};
 }
 
 /** Converts a string to lower case */
-inline auto to_lower(const std::string_view& str) {
+inline std::string to_lower(const std::string_view& str) {
   auto v = str | std::views::transform([](uint8_t c) { return static_cast<char>(std::tolower(c)); });
-  return std::string(v.begin(), v.end());
+  return {v.begin(), v.end()};
 }
 }  // namespace kn::string_utils

--- a/include/core/string_utils.hpp
+++ b/include/core/string_utils.hpp
@@ -1,0 +1,49 @@
+/**************************************************************************/
+/* common.hpp                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <cstring>
+#include <ranges>
+
+namespace kn::string_utils {
+/** Trims a string */
+auto trim(const std::string_view& str) {
+  auto v = str | std::views::drop_while(isspace) | std::views::reverse | std::views::drop_while(isspace) |
+           std::views::reverse;
+
+  return std::string(v.begin(), v.end());
+}
+
+/** Converts a string to lower case */
+std::string to_lower(const std::string_view& str) {
+  auto v = str | std::views::transform([](uint8_t c) { return static_cast<char>(std::tolower(c)); });
+  return std::string(v.begin(), v.end());
+}
+}  // namespace kn::string_utils

--- a/include/core/string_utils.hpp
+++ b/include/core/string_utils.hpp
@@ -34,7 +34,7 @@
 
 namespace kn::string_utils {
 /** Trims a string */
-auto trim(const std::string_view& str) {
+inline auto trim(const std::string_view& str) {
   auto v = str | std::views::drop_while(isspace) | std::views::reverse | std::views::drop_while(isspace) |
            std::views::reverse;
 
@@ -42,7 +42,7 @@ auto trim(const std::string_view& str) {
 }
 
 /** Converts a string to lower case */
-std::string to_lower(const std::string_view& str) {
+inline auto to_lower(const std::string_view& str) {
   auto v = str | std::views::transform([](uint8_t c) { return static_cast<char>(std::tolower(c)); });
   return std::string(v.begin(), v.end());
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,11 +6,13 @@ knoodle_create_module(
 target_sources(core
   PRIVATE
     
-    "memory/heap_allocator.cpp"    
+    "config/config_manager.cpp"    
+    "memory/stack_allocator.cpp"
     "memory/stack_allocator.cpp"
 
   PUBLIC
     "${KNOODLE_ROOT_DIR}/include/core/kn_assert.hpp"
+    "${KNOODLE_ROOT_DIR}/include/core/config/config_manager.hpp"
     "${KNOODLE_ROOT_DIR}/include/core/math/kn_math.hpp"
     "${KNOODLE_ROOT_DIR}/include/core/memory/heap_allocator.hpp"
     "${KNOODLE_ROOT_DIR}/include/core/memory/pool_allocator.hpp"
@@ -18,5 +20,5 @@ target_sources(core
 )
 
 knoodle_add_tests(NAME "TestMathOperations" COMMAND "math_ops_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/math/test_math_ops.cpp" DEPENDS core)
-# knoodle_add_tests(NAME "TestMemoryAllocators" COMMAND "memory_allocators_test" FILE "tests/memory/allocator_test.cpp" DEPENDS core)
-
+knoodle_add_tests(NAME "TestConfigSystem" COMMAND "config_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/config/test_config.cpp" DEPENDS core)
+knoodle_add_tests(NAME "TestStringUtils " COMMAND "string_utils_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/test_string_utils.cpp" DEPENDS core)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,3 +22,8 @@ target_sources(core
 knoodle_add_tests(NAME "TestMathOperations" COMMAND "math_ops_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/math/test_math_ops.cpp" DEPENDS core)
 knoodle_add_tests(NAME "TestConfigSystem" COMMAND "config_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/config/test_config.cpp" DEPENDS core)
 knoodle_add_tests(NAME "TestStringUtils " COMMAND "string_utils_test" FILE "${KNOODLE_ROOT_DIR}/tests/core/test_string_utils.cpp" DEPENDS core)
+
+add_custom_command(TARGET core POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${KNOODLE_ROOT_DIR}/tests/core/res
+    $<TARGET_FILE_DIR:core>/res)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,4 +26,4 @@ knoodle_add_tests(NAME "TestStringUtils " COMMAND "string_utils_test" FILE "${KN
 add_custom_command(TARGET core POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${KNOODLE_ROOT_DIR}/tests/core/res
-    $<TARGET_FILE_DIR:core>/res)
+    ${EXECUTABLE_OUTPUT_PATH}/res)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,4 +26,4 @@ knoodle_add_tests(NAME "TestStringUtils " COMMAND "string_utils_test" FILE "${KN
 add_custom_command(TARGET core POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${KNOODLE_ROOT_DIR}/tests/core/res
-    ${EXECUTABLE_OUTPUT_PATH}/res)
+    ${CMAKE_CURRENT_BINARY_DIR}/res)

--- a/src/core/config/config_manager.cpp
+++ b/src/core/config/config_manager.cpp
@@ -30,6 +30,7 @@
 #include "config/config_manager.hpp"
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 
 #include "string_utils.hpp"

--- a/src/core/config/config_manager.cpp
+++ b/src/core/config/config_manager.cpp
@@ -1,0 +1,143 @@
+/**************************************************************************/
+/* config_manager.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "config/config_manager.hpp"
+
+#include <algorithm>
+#include <fstream>
+
+#include "string_utils.hpp"
+
+namespace kn {
+ConfigManager& ConfigManager::get_instance() {
+  static ConfigManager instance;
+  return instance;
+}
+
+bool ConfigManager::load_config(const std::filesystem::path& file_path) {
+  std::ifstream file(file_path);
+  if (!file.is_open()) {
+    return false;
+  }
+  std::string line;
+  while (std::getline(file, line)) {
+    line = string_utils::trim(line);
+    parse_line(line);
+  }
+  return true;
+}
+
+std::set<std::string> ConfigManager::get_sections() const {
+  std::set<std::string> sections;
+  for (const auto& [key, _] : _config) {
+    const auto separator = key.find('.');
+    if (separator != std::string::npos) {
+      sections.insert(key.substr(0, separator));
+    }
+  }
+  return sections;
+}
+
+std::optional<std::string> ConfigManager::get_value(const std::string_view& key) const {
+  const auto it = _config.find(std::string(key));
+  if (it == _config.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+std::optional<int32_t> ConfigManager::get_int_value(const std::string_view& key) const {
+  const auto value = get_value(key);
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+  return std::stoi(value.value());
+}
+
+std::optional<real_t> ConfigManager::get_real_value(const std::string_view& key) const {
+  const auto value = get_value(key);
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+  return static_cast<real_t>(std::stof(value.value()));
+}
+
+std::optional<bool> ConfigManager::get_bool_value(const std::string_view& key) const {
+  const auto value = get_value(key);
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+
+  constexpr std::array<std::string_view, 4> true_values = {"true", "yes", "on", "1"};
+
+  return std::any_of(true_values.cbegin(), true_values.cend(),
+                     [value](std::string_view v) { return v == string_utils::to_lower(*value); });
+}
+
+void ConfigManager::parse_line(const std::string_view& line) {
+  if (line.empty()) {
+    parse_blank(line);
+    return;
+  }
+  if (line[0] == '#') {
+    parse_comment(line);
+    return;
+  }
+  if (line[0] == '[') {
+    parse_section(line);
+    return;
+  }
+  parse_key_value(line);
+}
+
+void ConfigManager::parse_blank(const std::string_view&) {
+  // Do nothing.
+}
+
+void ConfigManager::parse_comment(const std::string_view&) {
+  // Do nothing.
+}
+
+void ConfigManager::parse_section(const std::string_view& line) {
+  _current_section = line.substr(1, line.size() - 2);
+}
+
+void ConfigManager::parse_key_value(const std::string_view& line) {
+  const auto separator = line.find('=');
+  if (separator == std::string::npos) {
+    return;
+  }
+  auto key = std::string(line.substr(0, separator));
+  if (!_current_section.empty())
+    key = _current_section + '.' + key;
+  const auto value = line.substr(separator + 1);
+  _config[key] = std::string(value);
+}
+
+}  // namespace kn

--- a/src/core/config/config_manager.cpp
+++ b/src/core/config/config_manager.cpp
@@ -137,7 +137,7 @@ void ConfigManager::parse_key_value(const std::string_view& line) {
   if (!_current_section.empty())
     key = _current_section + '.' + key;
   const auto value = line.substr(separator + 1);
-  _config[key] = std::string(value);
+  _config.emplace(key, std::string(value));
 }
 
 }  // namespace kn

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/* test_math_ops.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "config/config_manager.hpp"
+
+TEST_CASE("ConfigManager") {
+  SUBCASE("load_config") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+    CHECK(config_manager.load_config("D:/Dev/knoodle/config/engine.ini"));
+  }
+
+  SUBCASE("get_sections") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+
+    auto sections = config_manager.get_sections();
+    CHECK(sections.size() != 0);
+    CHECK(sections.find("General") != sections.end());
+    CHECK(sections.find("Window") != sections.end());
+    CHECK(sections.find("Audio") != sections.end());
+    CHECK(sections.find("Graphics") != sections.end());
+  }
+
+  SUBCASE("get_value") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+
+    auto value = config_manager.get_value("General.AppName");
+    CHECK(value.has_value());
+
+    value = config_manager.get_value("General.Dummy");
+    CHECK(!value.has_value());
+  }
+
+  SUBCASE("get_int_value") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+    auto value = config_manager.get_int_value("Window.Width");
+    CHECK(value.has_value());
+    CHECK(value.value() == 1280);
+  }
+
+  SUBCASE("get_real_value") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+    auto value = config_manager.get_real_value("Window.AspectRatio");
+    CHECK(value.has_value());
+    CHECK(value.value() == doctest::Approx(1.778));
+  }
+
+  SUBCASE("get_bool_value") {
+    kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
+    auto value = config_manager.get_bool_value("Window.Fullscreen");
+    CHECK(value.has_value());
+    CHECK(!value.value());
+  }
+}

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -77,7 +77,7 @@ TEST_CASE("ConfigManager") {
     CHECK(value.has_value());
     CHECK(value.value() == doctest::Approx(1.778));
 
-    auto value2 = config_manager.get_int_value("Window.Unexisting");
+    auto value2 = config_manager.get_real_value("Window.Unexisting");
     CHECK(!value2.has_value());
   }
 
@@ -87,7 +87,7 @@ TEST_CASE("ConfigManager") {
     CHECK(value.has_value());
     CHECK(!value.value());
 
-    auto value2 = config_manager.get_int_value("Window.Unexisting");
+    auto value2 = config_manager.get_bool_value("Window.Unexisting");
     CHECK(!value2.has_value());
   }
 }

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -35,7 +35,7 @@
 TEST_CASE("ConfigManager") {
   SUBCASE("load_config") {
     kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
-    CHECK(config_manager.load_config("./res/test.ini"));
+    CHECK(config_manager.load_config("res/test.ini"));
   }
 
   SUBCASE("get_sections") {

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -35,7 +35,7 @@
 TEST_CASE("ConfigManager") {
   SUBCASE("load_config") {
     kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
-    CHECK(config_manager.load_config("res/test.ini"));
+    CHECK(config_manager.load_config("./res/test.ini"));
   }
 
   SUBCASE("get_sections") {

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -36,6 +36,8 @@ TEST_CASE("ConfigManager") {
   SUBCASE("load_config") {
     kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
     CHECK(config_manager.load_config("res/test.ini"));
+
+	CHECK(!config_manager.load_config("res/does_not_exist.ini"));
   }
 
   SUBCASE("get_sections") {
@@ -64,6 +66,9 @@ TEST_CASE("ConfigManager") {
     auto value = config_manager.get_int_value("Window.Width");
     CHECK(value.has_value());
     CHECK(value.value() == 1280);
+
+	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    CHECK(!value2.has_value());
   }
 
   SUBCASE("get_real_value") {
@@ -71,6 +76,9 @@ TEST_CASE("ConfigManager") {
     auto value = config_manager.get_real_value("Window.AspectRatio");
     CHECK(value.has_value());
     CHECK(value.value() == doctest::Approx(1.778));
+
+	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    CHECK(!value2.has_value());
   }
 
   SUBCASE("get_bool_value") {
@@ -78,5 +86,8 @@ TEST_CASE("ConfigManager") {
     auto value = config_manager.get_bool_value("Window.Fullscreen");
     CHECK(value.has_value());
     CHECK(!value.value());
+
+	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    CHECK(!value2.has_value());
   }
 }

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -37,7 +37,7 @@ TEST_CASE("ConfigManager") {
     kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
     CHECK(config_manager.load_config("res/test.ini"));
 
-	CHECK(!config_manager.load_config("res/does_not_exist.ini"));
+    CHECK(!config_manager.load_config("res/does_not_exist.ini"));
   }
 
   SUBCASE("get_sections") {
@@ -67,7 +67,7 @@ TEST_CASE("ConfigManager") {
     CHECK(value.has_value());
     CHECK(value.value() == 1280);
 
-	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    auto value2 = config_manager.get_int_value("Window.Unexisting");
     CHECK(!value2.has_value());
   }
 
@@ -77,7 +77,7 @@ TEST_CASE("ConfigManager") {
     CHECK(value.has_value());
     CHECK(value.value() == doctest::Approx(1.778));
 
-	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    auto value2 = config_manager.get_int_value("Window.Unexisting");
     CHECK(!value2.has_value());
   }
 
@@ -87,7 +87,7 @@ TEST_CASE("ConfigManager") {
     CHECK(value.has_value());
     CHECK(!value.value());
 
-	auto value2 = config_manager.get_int_value("Window.Unexisting");
+    auto value2 = config_manager.get_int_value("Window.Unexisting");
     CHECK(!value2.has_value());
   }
 }

--- a/tests/core/config/test_config.cpp
+++ b/tests/core/config/test_config.cpp
@@ -35,7 +35,7 @@
 TEST_CASE("ConfigManager") {
   SUBCASE("load_config") {
     kn::ConfigManager& config_manager = kn::ConfigManager::get_instance();
-    CHECK(config_manager.load_config("D:/Dev/knoodle/config/engine.ini"));
+    CHECK(config_manager.load_config("res/test.ini"));
   }
 
   SUBCASE("get_sections") {

--- a/tests/core/res/test.ini
+++ b/tests/core/res/test.ini
@@ -1,0 +1,17 @@
+[General]
+AppName=KnoodleEngine
+Version=1.0.0
+
+[Window]
+Width=1280
+Height=720
+AspectRatio=1.778
+Fullscreen=Off
+
+[Audio]
+MasterVolume=75
+MusicVolume=60
+SFXVolume=80
+
+[Graphics]
+API=Vulkan

--- a/tests/core/res/test.ini
+++ b/tests/core/res/test.ini
@@ -1,3 +1,6 @@
+# This file is used for test only
+# The variables below does not map to any real configuration
+
 [General]
 AppName=KnoodleEngine
 Version=1.0.0

--- a/tests/core/test_string_utils.cpp
+++ b/tests/core/test_string_utils.cpp
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/* test_math_ops.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                                Knoodle                                 */
+/*                        https://knoodlegraph.org                        */
+/**************************************************************************/
+/* Copyright (c) 2025 Knoodle contributors (vide AUTHORS.md)              */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "string_utils.hpp"
+
+TEST_CASE("StringUtils") {
+  SUBCASE("trim") {
+    CHECK(kn::string_utils::trim("  test  ") == "test");
+    CHECK(kn::string_utils::trim("test  ") == "test");
+    CHECK(kn::string_utils::trim("  test") == "test");
+    CHECK(kn::string_utils::trim("test") == "test");
+  }
+
+  SUBCASE("to_lower") {
+    CHECK(kn::string_utils::to_lower("TEST") == "test");
+    CHECK(kn::string_utils::to_lower("test") == "test");
+    CHECK(kn::string_utils::to_lower("TeSt") == "test");
+  }
+}


### PR DESCRIPTION
- Updated the CI configuration in `linux-ci.yml` to use a matrix strategy for different architectures (x64 and ARM64) and operating systems (Ubuntu latest).
- Changed the C++ standard version from 20 to 23 in `CMakeLists.txt`.
- Added installation rules for configuration files in `CMakeLists.txt`.
- Modified the `knoodle_create_module` function in `KnoodleModule.cmake` to change the visibility of compile options from `PRIVATE` to `PUBLIC`.
- Added a new configuration file `engine.ini` with various settings for the application.
- Added a new header file `common.hpp` with a copyright notice and a type alias for `real_t`.
- Added a new header file `config_manager.hpp` with a `ConfigManager` class to manage application configuration.
- Removed the `real_t` type alias from `kn_math.hpp` and included `common.hpp` instead.
- Added a new header file `string_utils.hpp` with utility functions for string manipulation.
- Updated `CMakeLists.txt` to include new source files and headers for the configuration manager and string utilities.
- Added new tests for the configuration manager in `test_config.cpp`.
- Added new tests for string utilities in `test_string_utils.cpp`.
- Added a new source file `config_manager.cpp` implementing the `ConfigManager` class.